### PR TITLE
Ajout de endpoint REST `/fire` pour récupérer les résidents et leurs informations médicales à une adresse donnée

### DIFF
--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/controller/FireStationController.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/controller/FireStationController.java
@@ -1,6 +1,7 @@
 package com.openclassrooms.safetynet.safetynetapi.controller;
 
 import com.openclassrooms.safetynet.safetynetapi.dto.CoveredPersonsByStationDTO;
+import com.openclassrooms.safetynet.safetynetapi.dto.FireStationResidentsDTO;
 import com.openclassrooms.safetynet.safetynetapi.model.FireStation;
 import com.openclassrooms.safetynet.safetynetapi.service.FireStationService;
 import lombok.extern.log4j.Log4j2;
@@ -158,6 +159,29 @@ public class FireStationController {
     @GetMapping("/firestation")
     public ResponseEntity<CoveredPersonsByStationDTO> getPersonsCoveredByStation(@RequestParam("stationNumber") int stationNumber) {
         CoveredPersonsByStationDTO response = fireStationService.getPersonsCoveredByStation(stationNumber);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * GET endpoint that retrieves residents and medical information for a given address.
+     *
+     * <p>This endpoint returns:
+     * <ul>
+     *   <li>The fire station number serving the specified address</li>
+     *   <li>A list of residents living at that address, each including their name, phone number, age,
+     *       medications, and allergies</li>
+     * </ul>
+     *
+     * <p>Example request: <code>/fire?address=1509 Culver St</code></p>
+     * <p>If no fire station is found for the given address, this endpoint will respond with an appropriate HTTP error status.</p>
+     *
+     * @param address the address to look up
+     * @return a ResponseEntity containing a FireStationResidentsDTO with fire station number
+     * and resident details; returns HTTP 200 OK on success
+     */
+    @GetMapping("/fire")
+    public ResponseEntity<FireStationResidentsDTO> getResidentsByAddress(@RequestParam String address) {
+        FireStationResidentsDTO response = fireStationService.getResidentsByAddress(address);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/FirePersonInfoDTO.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/FirePersonInfoDTO.java
@@ -1,0 +1,17 @@
+package com.openclassrooms.safetynet.safetynetapi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class FirePersonInfoDTO {
+    private String firstName;
+    private String lastName;
+    private String phone;
+    private int age;
+    private List<String> medications;
+    private List<String> allergies;
+}

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/FireStationResidentsDTO.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/FireStationResidentsDTO.java
@@ -1,0 +1,13 @@
+package com.openclassrooms.safetynet.safetynetapi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class FireStationResidentsDTO {
+    private int fireStationNumber;
+    private List<FirePersonInfoDTO> residents;
+}


### PR DESCRIPTION
- **Ajout de DTO**
  - `FirePersonInfoDTO` : encapsule le nom, le téléphone, l’âge, les médicaments et les allergies d’un résident
  - `FireStationResidentsDTO` : contient le numéro de la caserne et la liste des résidents concernés

- **Contrôleur**
  - `FireStationController` : ajout de l’endpoint `GET /fire` avec un paramètre `address`

- **Service**
  - `FireStationService#getResidentsByAddress(String address)` qui :
    - récupère la caserne via le `FireStationRepository`
    - récupère les personnes vivant à l'adresse via le `PersonRepository`
    - récupère les dossiers médicaux via le `MedicalRecordRepository`
    - calcule l'âge à partir de la date de naissance avec `AgeUtil`

- **Gestion des erreurs**
  - Retourne une erreur appropriée si aucune caserne ou aucun résident n’est trouvé à l’adresse donnée

- **Documentation**
  - Ajout de JavaDoc sur les méthodes du contrôleur et du service pour faciliter la compréhension

- **Tests**
  - Test manuel effectué avec Postman (`/fire?address=1509 Culver St`)