### PR TITLE
fix: return 200 OK with empty list for /childAlert when no children found

### DIFF
--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/controller/AlertInfoController.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/controller/AlertInfoController.java
@@ -81,12 +81,8 @@ public class AlertInfoController {
         log.info("Request received for /childAlert with address : {}", address);
         List <ChildDTO> children = alertInfoService.getChildrenByAddress(address);
 
-        if(children.isEmpty()){
-            log.warn("No children found at this address {}:", address);
-            return ResponseEntity.noContent().build();
-        }
         log.info("{} child(ren) found at address {}", children.size(), address);
-        return ResponseEntity.ok(children);
+        return ResponseEntity.ok(children); //  always status 200 Ok, even if no children found (empty list)
     }
 
     /**

--- a/src/test/java/com/openclassrooms/safetynet/safetynetapi/controller/AlertInfoControllerIT.java
+++ b/src/test/java/com/openclassrooms/safetynet/safetynetapi/controller/AlertInfoControllerIT.java
@@ -184,10 +184,12 @@ public class AlertInfoControllerIT {
     }
 
     @Test
-    public void getChildrenByAddress_shouldReturnNoContent_whenNoChildrenFound() throws Exception {
+    public void getChildrenByAddress_shouldReturnEmptyList_whenNoChildrenFound() throws Exception {
         mockMvc.perform(get("/childAlert")
                         .param("address", "Unknown Address"))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(0));
     }
 
     @Test


### PR DESCRIPTION
- Removed logic returning 204 No Content for /childAlert endpoint when no children are found at the given address.
- The endpoint now consistently returns 200 OK with an empty JSON array ([]).
- Updated corresponding integration test to expect 200 OK with an empty list instead of 204.