### PR TITLE
Refactor: clean up Lombok annotations and unused dependencies in services and models

### DIFF
--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/AddressResidentsDTO.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/AddressResidentsDTO.java
@@ -1,11 +1,11 @@
 package com.openclassrooms.safetynet.safetynetapi.dto;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 
 import java.util.List;
 
-@Data
+@Getter
 @AllArgsConstructor
 public class AddressResidentsDTO {
     private String address;

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/ChildDTO.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/ChildDTO.java
@@ -1,11 +1,12 @@
 package com.openclassrooms.safetynet.safetynetapi.dto;
 
-
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 
-@Data
+@Getter
+@Setter
 public class ChildDTO {
     private String firstName;
     private String lastName;

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/CoveredPersonsByStationDTO.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/CoveredPersonsByStationDTO.java
@@ -1,11 +1,12 @@
 package com.openclassrooms.safetynet.safetynetapi.dto;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 
-
-@Data
+@Getter
+@Setter
 public class CoveredPersonsByStationDTO {
     private List<CoveredPersonsDTO> coveredPersons;
     private int nbAdults;

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/CoveredPersonsDTO.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/CoveredPersonsDTO.java
@@ -1,8 +1,10 @@
 package com.openclassrooms.safetynet.safetynetapi.dto;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 public class CoveredPersonsDTO {
     private String firstName;
     private String lastName;

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/FirePersonInfoDTO.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/FirePersonInfoDTO.java
@@ -1,11 +1,11 @@
 package com.openclassrooms.safetynet.safetynetapi.dto;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 
 import java.util.List;
 
-@Data
+@Getter
 @AllArgsConstructor
 public class FirePersonInfoDTO {
     private String firstName;

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/FireStationDTO.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/FireStationDTO.java
@@ -3,7 +3,7 @@ package com.openclassrooms.safetynet.safetynetapi.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
  *
  * @author Sarar
  */
-@Data
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/FireStationResidentsDTO.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/FireStationResidentsDTO.java
@@ -1,11 +1,11 @@
 package com.openclassrooms.safetynet.safetynetapi.dto;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 
 import java.util.List;
 
-@Data
+@Getter
 @AllArgsConstructor
 public class FireStationResidentsDTO {
     private int fireStationNumber;

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/HouseholdMembersDTO.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/HouseholdMembersDTO.java
@@ -1,8 +1,10 @@
 package com.openclassrooms.safetynet.safetynetapi.dto;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 public class HouseholdMembersDTO {
     private String firstName;
     private String lastName;

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/MedicalRecordDTO.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/MedicalRecordDTO.java
@@ -3,7 +3,7 @@ package com.openclassrooms.safetynet.safetynetapi.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
@@ -20,7 +20,7 @@ import java.util.List;
  *
  * @author Sarar
  */
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/PersonDTO.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/PersonDTO.java
@@ -2,13 +2,13 @@ package com.openclassrooms.safetynet.safetynetapi.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Data
+@Getter
 public class PersonDTO {
     private String firstName;
     private String lastName;

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/PersonInfoDto.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/dto/PersonInfoDto.java
@@ -1,11 +1,11 @@
 package com.openclassrooms.safetynet.safetynetapi.dto;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 
 import java.util.List;
 
-@Data
+@Getter
 @AllArgsConstructor
 public class PersonInfoDto {
     private String firstName;

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/model/DataFile.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/model/DataFile.java
@@ -1,16 +1,17 @@
 package com.openclassrooms.safetynet.safetynetapi.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 
 /**
  * Represents the data structure holding all records loaded from the data file.
- *
  * Contains lists of persons, fire stations, and medical records.
  */
-@Data
+@Getter
+@Setter
 public class DataFile {
     private List<Person> persons;
     @JsonProperty("firestations")

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/model/FireStation.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/model/FireStation.java
@@ -2,7 +2,8 @@ package com.openclassrooms.safetynet.safetynetapi.model;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Represents a firestation mapping an address to a station number.
@@ -14,7 +15,8 @@ import lombok.Data;
  *
  * @author [Sarar]
  */
-@Data
+@Getter
+@Setter
 @AllArgsConstructor
 public class FireStation {
     private String address;

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/model/MedicalRecord.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/model/MedicalRecord.java
@@ -2,9 +2,7 @@ package com.openclassrooms.safetynet.safetynetapi.model;
 
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -23,7 +21,8 @@ import java.util.List;
  */
 @NoArgsConstructor
 @AllArgsConstructor
-@Data
+@Getter
+@Setter
 public class MedicalRecord {
 
     private String firstName;

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/model/Person.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/model/Person.java
@@ -1,6 +1,7 @@
 package com.openclassrooms.safetynet.safetynetapi.model;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Represents a person with personal and contact details.
@@ -13,7 +14,8 @@ import lombok.Data;
  *
  * @author [Sarar]
  */
-@Data
+@Getter
+@Setter
 public class Person {
     private String firstName;
     private String lastName;

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/repository/FireStationRepository.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/repository/FireStationRepository.java
@@ -19,8 +19,6 @@ public interface FireStationRepository {
 
     boolean deleteFirstOccurrenceFireStationByAddress(String address);
 
-    boolean deleteAllFireStationByAddress(String address);
-
     boolean deleteByStationNumber(int stationNumber);
 
     List<String> getAddressesByStation(Integer stationNumber);

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/repository/InMemoryFireStationRepository.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/repository/InMemoryFireStationRepository.java
@@ -153,31 +153,6 @@ public class InMemoryFireStationRepository implements FireStationRepository {
     }
 
     /**
-     * Deletes all fire stations matching the specified address.
-     * <p>
-     * If any fire stations with the given address are found, they are removed from the in-memory list,
-     * the data file is updated, and the changes are saved to the JSON file.
-     * </p>
-     *
-     * @param address the address of the fire stations to delete
-     * @return true if one or more fire stations were found and deleted; false otherwise
-     */
-    @Override
-    public boolean deleteAllFireStationByAddress(String address) {
-        boolean removed = fireStations.removeIf(fs -> fs.getAddress().equalsIgnoreCase(address));
-        if (removed) {
-            log.debug("All firestations with address '{}' deleted", address);
-
-            // Update source DataFile and save JSON
-            dataLoader.getDataFile().setFireStations(fireStations);
-            dataLoader.saveJsonFile();
-        } else {
-            log.debug("No firestation at all found with address '{}', nothing deleted", address);
-        }
-        return removed;
-    }
-
-    /**
      * Deletes all fire stations matching the specified station number.
      * <p>
      * If any fire stations with the given station number are found, they are removed from the in-memory list,

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/service/FireStationService.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/service/FireStationService.java
@@ -5,10 +5,7 @@ import com.openclassrooms.safetynet.safetynetapi.exception.FireStationAlreadyExi
 import com.openclassrooms.safetynet.safetynetapi.exception.FireStationNotFoundException;
 import com.openclassrooms.safetynet.safetynetapi.model.FireStation;
 import com.openclassrooms.safetynet.safetynetapi.repository.FireStationRepository;
-import com.openclassrooms.safetynet.safetynetapi.repository.MedicalRecordRepository;
-import com.openclassrooms.safetynet.safetynetapi.repository.PersonRepository;
 import com.openclassrooms.safetynet.safetynetapi.service.mapper.FireStationMapper;
-import lombok.Data;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -25,17 +22,10 @@ import java.util.*;
  */
 @Log4j2
 @Service
-@Data
 public class FireStationService {
 
     @Autowired
-    private PersonRepository personRepository;
-
-    @Autowired
     private FireStationRepository fireStationRepository;
-
-    @Autowired
-    private MedicalRecordRepository medicalRecordRepository;
 
     @Autowired
     private FireStationMapper fireStationMapper;

--- a/src/main/java/com/openclassrooms/safetynet/safetynetapi/service/PersonService.java
+++ b/src/main/java/com/openclassrooms/safetynet/safetynetapi/service/PersonService.java
@@ -27,16 +27,12 @@ import java.util.stream.Collectors;
  */
 @Log4j2
 @Service
-@Data
 public class PersonService {
     @Autowired
     private PersonRepository personRepository;
 
     @Autowired
     private PersonMapper personMapper;
-
-    @Autowired
-    private MedicalRecordRepository medicalRecordRepository;
 
     /**
      * Retrieves all persons from the repository.


### PR DESCRIPTION
- Removed `@Data` from `FireStationService` and `PersonService` (services should not use `@Data`)
- Removed unused `@Autowired` dependencies (`personRepository`, `medicalRecordRepository`) from `FireStationService`
- Removed unused `@Autowired medicalRecordRepository` from `PersonService`
- Replaced `@Data` in DTOs and model classes with more specific annotations (`@Getter`, `@Setter`, etc.) to avoid generating unnecessary methods like `equals()`, `hashCode()`, and `toString()`, which were not used and reduced jacoco code coverage.